### PR TITLE
Add social media links to footer

### DIFF
--- a/docs/mint.config.json
+++ b/docs/mint.config.json
@@ -107,10 +107,7 @@
     },
     {
       "group": "Lab Testing",
-      "pages": [
-        "lab/home/introduction",
-        "lab/home/testing-modalities"
-      ]
+      "pages": ["lab/home/introduction", "lab/home/testing-modalities"]
     },
     {
       "group": "Workflow",
@@ -123,9 +120,7 @@
     },
     {
       "group": "Results",
-      "pages": [
-        "lab/results/result-formats"
-      ]
+      "pages": ["lab/results/result-formats"]
     },
     {
       "group": "User",
@@ -141,9 +136,7 @@
     },
     {
       "group": "Providers",
-      "pages": [
-        "api-reference/providers"
-      ]
+      "pages": ["api-reference/providers"]
     },
     {
       "group": "Link",
@@ -187,10 +180,7 @@
     },
     {
       "group": "Body",
-      "pages": [
-        "api-reference/body/get-summary",
-        "api-reference/body/get-raw"
-      ]
+      "pages": ["api-reference/body/get-summary", "api-reference/body/get-raw"]
     },
     {
       "group": "Vitals",
@@ -214,9 +204,7 @@
     },
     {
       "group": "Lab Tests",
-      "pages": [
-        "api-reference/lab-tests"
-      ]
+      "pages": ["api-reference/lab-tests"]
     },
     {
       "group": "Results",
@@ -237,5 +225,10 @@
         "api-reference/legacy/results/get-results-metadata"
       ]
     }
-  ]
+  ],
+  "footerSocials": {
+    "website": "https://tryvital.io",
+    "twitter": "https://twitter.com/tryVital",
+    "linkedin": "https://www.linkedin.com/company/tryvital"
+  }
 }


### PR DESCRIPTION
# Summary
This PR adds social icons at the footer to link the documentation with the Corrily website, Twitter, and LinkedIn (for better SEO and user flow)

<img width="162" alt="Screen Shot 2022-08-26 at 5 04 51 PM" src="https://user-images.githubusercontent.com/44352119/187006108-b083eed1-cf71-41e7-90a2-789e75da7966.png">
