### PR TITLE
Fix out of sync api reference pages

### DIFF
--- a/docs/api-reference/providers.mdx
+++ b/docs/api-reference/providers.mdx
@@ -1,6 +1,6 @@
 ---
 title: "List of Providers"
-openapi: "GET /v2/providers/"
+openapi: "GET /v2/providers"
 ---
 
 <RequestExample>

--- a/docs/api-reference/user/create-user.mdx
+++ b/docs/api-reference/user/create-user.mdx
@@ -1,5 +1,5 @@
 ---
-openapi: "POST /v2/user/"
+openapi: "POST /v2/user"
 ---
 
 <RequestExample>

--- a/docs/api-reference/user/get-users.mdx
+++ b/docs/api-reference/user/get-users.mdx
@@ -1,5 +1,5 @@
 ---
-openapi: "GET /v2/user/"
+openapi: "GET /v2/user"
 ---
 
 <RequestExample>


### PR DESCRIPTION
## Summary
Seems that when [this commit](https://github.com/tryVital/docs/commit/c707f1f154621d560fbb3c607c73b991f81fd371#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R4297) updating the swagger spec was pushed, some of the endpoints' trailing `/`s were removed. This PR updates the corresponding mdx files to follow the newly updated swagger spec.