### PR TITLE
Fix link to lab testing section

### DIFF
--- a/docs/home/welcome.mdx
+++ b/docs/home/welcome.mdx
@@ -35,7 +35,7 @@ description: "Here you'll find guides, resources, and references to build using 
     title="Labs and Test Kits"
     icon="flask"
     color="#BF40BF"
-    href="/lab/home/introduction"
+    href="/lab/overview/introduction"
   >
     Vital’s lab test API allows digital health companies to carry out at-home
     lab testing. Companies can use the API to order a variety of tests, using


### PR DESCRIPTION
The link to the `Labs and Test Kits` section is broken, so quick fix :)

Live broken version:
![not_working](https://github.com/tryVital/docs/assets/50703175/15bd339a-b9fc-4d30-b8c7-fb51a4ddff3c)

Local fix:
![working](https://github.com/tryVital/docs/assets/50703175/c68d401f-49ca-4fcd-9ce3-0dd558cfd5a2)
