### PR TITLE
feat: add lacking documentation for fasting and insurance form additional info

### DIFF
--- a/docs/api-reference/lab-testing/create-order.mdx
+++ b/docs/api-reference/lab-testing/create-order.mdx
@@ -39,6 +39,12 @@ data = client.LabTests.create_order(
          "content": "base64-encoded insurance back image binary content",
          "content_type": "image/png",
       },
+      "patient_signature_image": {
+         "content": "base64-encoded patient signature image binary content",
+         "content_type": "image/png",
+      },
+      "subjective": "Description of what is the patient symptoms and attempted treatments",
+      "assessment_plan": "Description of what is the physician assessment and treament or testing plan",
     },
     consents=[
       {"consentType": "terms-of-use"},

--- a/docs/api-reference/lab-testing/post-test.mdx
+++ b/docs/api-reference/lab-testing/post-test.mdx
@@ -17,6 +17,7 @@ data = client.LabTests.create_test(
   method="testkit",
   sample_type="dried_blood_spot",
   markers=[160],
+  fasting=False
 )
 
 ```
@@ -34,6 +35,7 @@ data = client.LabTests.create_test(
     "method": "testkit",
     "price": 10.0,
     "is_active": false,
+    "fasting": false,
     "lab": {
       "slug": "USSL",
       "name": "US Specialty Lab",

--- a/docs/api-reference/lab-testing/post-test.mdx
+++ b/docs/api-reference/lab-testing/post-test.mdx
@@ -16,8 +16,7 @@ data = client.LabTests.create_test(
   lab_id=5,
   method="testkit",
   sample_type="dried_blood_spot",
-  markers=[160],
-  fasting=False
+  markers=[160]
 )
 
 ```


### PR DESCRIPTION

Add example fields for fasting and health insurance information in python client. Update responses where needed.