### PR TITLE
[VIT-3353] Add trigger on custom event; to be sent from mono

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -7,7 +7,11 @@ on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
     branches: [ "*" ]
-
+  
+  # triggered on a custom event
+  repository_dispatch:
+    types: [trigger_ci]
+ 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Adds a trigger on a custom event. This event will be sent from mono repo on release to trigger the swagger json pull