### PR TITLE
Update timeseries examples wrt measurement type

### DIFF
--- a/docs/api-reference/activity-timeseries/calories_active.mdx
+++ b/docs/api-reference/activity-timeseries/calories_active.mdx
@@ -28,7 +28,7 @@ Not implemented yet.
     "end": "2022-04-20T13:03:01.123771+00:00",
     "timezone_offset": 3600,
     "value": 123,
-    "type": "automatic",
+    "type": null,
     "unit": "kcal"
   }
 ]

--- a/docs/api-reference/activity-timeseries/calories_basal.mdx
+++ b/docs/api-reference/activity-timeseries/calories_basal.mdx
@@ -26,7 +26,7 @@ Not implemented yet.
     "timestamp": "2022-04-20T13:02:01.123771+00:00",
     "timezone_offset": 3600,
     "value": 123,
-    "type": "automatic",
+    "type": null,
     "unit": "kcal"
   }
 ]

--- a/docs/api-reference/activity-timeseries/distance.mdx
+++ b/docs/api-reference/activity-timeseries/distance.mdx
@@ -28,7 +28,7 @@ Not implemented yet.
     "end": "2022-04-20T13:03:01.123771+00:00",
     "timezone_offset": 3600,
     "value": 123,
-    "type": "automatic",
+    "type": null,
     "unit": "m"
   }
 ]

--- a/docs/api-reference/activity-timeseries/floors_climbed.mdx
+++ b/docs/api-reference/activity-timeseries/floors_climbed.mdx
@@ -26,7 +26,7 @@ Not implemented yet.
     "timestamp": "2022-04-20T13:02:01.123771+00:00",
     "timezone_offset": 3600,
     "value": 123,
-    "type": "automatic",
+    "type": null,
     "unit": "count"
   }
 ]

--- a/docs/api-reference/activity-timeseries/steps.mdx
+++ b/docs/api-reference/activity-timeseries/steps.mdx
@@ -28,7 +28,7 @@ Not implemented yet.
     "start": "2022-04-20T13:02:01.123771+00:00",
     "end": "2022-04-20T13:03:01.123771+00:00",
     "value": 123,
-    "type": "automatic",
+    "type": null,
     "unit": "count"
   }
 ]

--- a/docs/api-reference/sleep/get-stream.mdx
+++ b/docs/api-reference/sleep/get-stream.mdx
@@ -31,35 +31,35 @@ data = await client.Sleep.getStream(sleep_id=*)
       "id": 0,
       "timestamp": "2022-08-04T12:42:45.722013+00:00",
       "value": 98,
-      "type": "automatic",
+      "type": null,
       "unit": "rmssd"
     },
     {
       "id": 1,
       "timestamp": "2022-08-04T12:43:15.722058+00:00",
       "value": 44,
-      "type": "automatic",
+      "type": null,
       "unit": "rmssd"
     },
     {
       "id": 2,
       "timestamp": "2022-08-04T12:43:45.722075+00:00",
       "value": 75,
-      "type": "automatic",
+      "type": null,
       "unit": "rmssd"
     },
     {
       "id": 3,
       "timestamp": "2022-08-04T12:44:15.722089+00:00",
       "value": 100,
-      "type": "automatic",
+      "type": null,
       "unit": "rmssd"
     },
     {
       "id": 4,
       "timestamp": "2022-08-04T12:44:45.722101+00:00",
       "value": 59,
-      "type": "automatic",
+      "type": null,
       "unit": "rmssd"
     }
   ],
@@ -68,35 +68,35 @@ data = await client.Sleep.getStream(sleep_id=*)
       "id": 0,
       "timestamp": "2022-08-04T12:42:45.722112+00:00",
       "value": 29,
-      "type": "automatic",
+      "type": null,
       "unit": "bpm"
     },
     {
       "id": 1,
       "timestamp": "2022-08-04T12:43:15.722124+00:00",
       "value": 162,
-      "type": "automatic",
+      "type": null,
       "unit": "bpm"
     },
     {
       "id": 2,
       "timestamp": "2022-08-04T12:43:45.722135+00:00",
       "value": 75,
-      "type": "automatic",
+      "type": null,
       "unit": "bpm"
     },
     {
       "id": 3,
       "timestamp": "2022-08-04T12:44:15.722146+00:00",
       "value": 11,
-      "type": "automatic",
+      "type": null,
       "unit": "bpm"
     },
     {
       "id": 4,
       "timestamp": "2022-08-04T12:44:45.722157+00:00",
       "value": 41,
-      "type": "automatic",
+      "type": null,
       "unit": "bpm"
     }
   ],
@@ -152,35 +152,35 @@ data = await client.Sleep.getStream(sleep_id=*)
       "id": 0,
       "timestamp": "2022-08-04T12:42:45.722223+00:00",
       "value": 30,
-      "type": "automatic",
+      "type": null,
       "unit": "bpm"
     },
     {
       "id": 1,
       "timestamp": "2022-08-04T12:43:15.722234+00:00",
       "value": 29,
-      "type": "automatic",
+      "type": null,
       "unit": "bpm"
     },
     {
       "id": 2,
       "timestamp": "2022-08-04T12:43:45.722245+00:00",
       "value": 19,
-      "type": "automatic",
+      "type": null,
       "unit": "bpm"
     },
     {
       "id": 3,
       "timestamp": "2022-08-04T12:44:15.722256+00:00",
       "value": 14,
-      "type": "automatic",
+      "type": null,
       "unit": "bpm"
     },
     {
       "id": 4,
       "timestamp": "2022-08-04T12:44:45.722266+00:00",
       "value": 18,
-      "type": "automatic",
+      "type": null,
       "unit": "bpm"
     }
   ]

--- a/docs/api-reference/vitals/blood-pressure.mdx
+++ b/docs/api-reference/vitals/blood-pressure.mdx
@@ -27,7 +27,7 @@ Not implemented yet.
     "timestamp": "2022-08-04T12:42:45.727135+00:00",
     "systolic": "125",
     "diastolic": "75",
-    "type": "cuff",
+    "type": null,
     "unit": "mmHg"
   }
 ]

--- a/docs/api-reference/vitals/caffeine.mdx
+++ b/docs/api-reference/vitals/caffeine.mdx
@@ -28,7 +28,7 @@ Not implemented yet.
     "start": "2022-04-20T13:02:01.123771+00:00",
     "end": "2022-04-20T13:03:01.123771+00:00",
     "value": 42,
-    "type": "automatic",
+    "type": null,
     "unit": "g"
   }
 ]

--- a/docs/api-reference/vitals/heartrate.mdx
+++ b/docs/api-reference/vitals/heartrate.mdx
@@ -30,7 +30,7 @@ data = client.Vitals.heartrate(
     "id": 123,
     "timestamp": "2022-04-20T13:02:01.123771+00:00",
     "value": "70",
-    "type": "automatic",
+    "type": null,
     "unit": "bpm"
   }
 ]

--- a/docs/api-reference/vitals/hrv.mdx
+++ b/docs/api-reference/vitals/hrv.mdx
@@ -26,7 +26,7 @@ Not implemented yet.
     "id": null,
     "timestamp": "2022-04-20T13:02:01.123771+00:00",
     "value": "48",
-    "type": "automatic",
+    "type": null,
     "unit": "rmssd"
   }
 ]

--- a/docs/api-reference/vitals/hypnogram.mdx
+++ b/docs/api-reference/vitals/hypnogram.mdx
@@ -28,7 +28,7 @@ Not implemented yet.
     "start": "2022-04-20T13:02:01.123771+00:00",
     "end": "2022-04-20T13:03:01.123771+00:00",
     "value": 1,
-    "type": "automatic",
+    "type": null,
     "unit": "stage"
   }
 ]

--- a/docs/api-reference/vitals/mindfulness-minutes.mdx
+++ b/docs/api-reference/vitals/mindfulness-minutes.mdx
@@ -28,7 +28,7 @@ Not implemented yet.
     "start": "2023-01-19T13:50:31+00:00",
     "end": "2023-01-19T13:51:31+00:00",
     "value": 60.0,
-    "type": "automatic",
+    "type": null,
     "unit": "min"
   }
 ]

--- a/docs/api-reference/vitals/respiratory-rate.mdx
+++ b/docs/api-reference/vitals/respiratory-rate.mdx
@@ -26,7 +26,7 @@ Not implemented yet.
     "id": null,
     "timestamp": "2022-04-20T13:02:01.123771+00:00",
     "value": "45",
-    "type": "automatic",
+    "type": null,
     "unit": "bpm"
   }
 ]

--- a/docs/api-reference/vitals/water.mdx
+++ b/docs/api-reference/vitals/water.mdx
@@ -26,7 +26,7 @@ Not implemented yet.
     "id": null,
     "timestamp": "2022-04-20T13:02:01.123771+00:00",
     "value": 400,
-    "type": "automatic",
+    "type": null,
     "unit": "ml"
   }
 ]

--- a/docs/wearables/providers/resources.mdx
+++ b/docs/wearables/providers/resources.mdx
@@ -86,35 +86,35 @@ For example, `Workouts` is made up of fields specific to an workout, like calori
     "id": 79009531,
     "timestamp": "2022-04-29T08:35:57+00:00",
     "value": 174.0,
-    "type": "automatic",
+    "type": null,
     "unit": "bpm"
   },
   {
     "id": 79005064,
     "timestamp": "2022-04-30T11:22:38+00:00",
     "value": 79.0,
-    "type": "automatic",
+    "type": null,
     "unit": "bpm"
   },
   {
     "id": 79005065,
     "timestamp": "2022-04-30T11:22:39+00:00",
     "value": 80.0,
-    "type": "automatic",
+    "type": null,
     "unit": "bpm"
   },
   {
     "id": 79005066,
     "timestamp": "2022-04-30T11:22:40+00:00",
     "value": 78.0,
-    "type": "automatic",
+    "type": null,
     "unit": "bpm"
   },
   {
     "id": 79005067,
     "timestamp": "2022-04-30T11:22:41+00:00",
     "value": 78.0,
-    "type": "automatic",
+    "type": null,
     "unit": "bpm"
   }
 ]

--- a/docs/webhooks/event-structure.mdx
+++ b/docs/webhooks/event-structure.mdx
@@ -139,14 +139,14 @@ and some may even send updates ASAP on time buckets that have incomplete data. F
       {
         "timestamp": "2023-05-16T10:00:00+00:00",
         "timezone_offset": 3600,
-        "type": "automatic",
+        "type": null,
         "unit": "count",
         "value": 237
       },
       {
         "timestamp": "2023-05-16T11:00:00+00:00",
         "timezone_offset": 3600,
-        "type": "automatic",
+        "type": null,
         "unit": "count",
         "value": 451
       },


### PR DESCRIPTION
`type` is now dedicated to measurement types (cholesterol/igg/ige) and no longer reflects source type. The sentinel value has been standardized as `null` rather than `"automatic"`.