### PR TITLE
Clarify update frequency of SDK Based Providers

### DIFF
--- a/docs/wearables/providers/introduction.mdx
+++ b/docs/wearables/providers/introduction.mdx
@@ -81,27 +81,28 @@ We currently Support over 300+ devices, a full list can be seen below.
 </iframe>
 
 ## Data Frequency
+Whenever Vital detects that new data is available, [data events](/event-catalog) are always sent to your configured endpoints, regardless of the provider being push-based or polling-based.
 
-This section describes how we fetch data from the different providers. For all of them, we send you webhook updates when new data is available. The difference is how frequently we fetch data.
+### Cloud Based Providers
+Cloud Based Providers can be divided in two main categories:
 
-Whenever possible, we set up our integrations so that we are immediately notified when new data is available. These are the providers marked as `Webhook` in the table below. For these providers, we fetch the latest data as soon as it is available and we send a webhook update.
+* Push-based
 
-For the other providers, marked as `Polling` below, we periodically fetch the latest data every 10-15 minutes. If you want more granular control over this, you can use the [refresh endpoint](/api-reference/user#refresh-users-data) to fetch the latest data immediately.
+    * When a cloud-based provider supports a push notify mechanism (typically webhooks), Vital would prefer to use it to drive data fetches. In other words, as soon as the provider notifies Vital of new data through the said mechanism, Vital fetches the latest data.
 
-All data can be fetched instantaneously, some are configured via our live refresh endpoint and others are automatically kept up to date via our webhook implementation.
+* Polling-based
+
+    * For providers and/or resources without any push notify mechanism, Vital polls these resources at a regular schedule, typically every 15 minutes or so.
+
 
 | Provider                                                        | Description |
 | --------------------------------------------------------------- | ----------- |
-| [Fitbit](https://www.fitbit.com/global/uk/home)                 | Webhook     |
-| [Garmin](https://www.garmin.com)                                | Webhook     |
-| [Strava](https://www.strava.com)                                | Webhook     |
-| [Wahoo](https://wahoofitness.com)                               | Webhook     |
-| [Withings](https://www.withings.com)                            | Webhook     |
-| [iHealth](https://ihealthlabs.com)                              | Webhook     |
-| [Omron](https://www.omron-healthcare.com) (SDK)                 | Webhook     |
-| [Contour](https://www.diabetes.ascensia.com) (SDK)              | Webhook     |
-| [Accu-Chek](https://www.accu-chek.com) (SDK)                    | Webhook     |
-| [Apple HealthKit](https://www.apple.com/uk/ios/health/) (SDK)   | Webhook     |
+| [Fitbit](https://www.fitbit.com/global/uk/home)                 | Push        |
+| [Garmin](https://www.garmin.com)                                | Push        |
+| [Strava](https://www.strava.com)                                | Push        |
+| [Wahoo](https://wahoofitness.com)                               | Push        |
+| [Withings](https://www.withings.com)                            | Push        |
+| [iHealth](https://ihealthlabs.com)                              | Push        |
 | [Freestyle](https://www.freestylelibre.co.uk/libre/)(API + SDK) | Polling     |
 | [Google Fit](https://www.google.com/fit/)                       | Polling     |
 | [Oura](https://ouraring.com)                                    | Polling     |
@@ -113,6 +114,48 @@ All data can be fetched instantaneously, some are configured via our live refres
 | [Hammerhead](https://www.hammerhead.io)                         | Polling     |
 | [Dexcom](https://www.dexcom.com)                                | Polling     |
 | [MyFitnessPal](https://www.myfitnesspal.com)                    | Polling     |
+
+### SDK Based Providers
+
+SDK Based Providers are all push-based, where data are pushed from the Vital SDK embedded inside your Android or iOS app.
+
+| Provider                                                                 | Description |
+| ------------------------------------------------------------------------ | ----------- |
+| [Apple HealthKit](https://www.apple.com/uk/ios/health/)                  | Sync on OS notification, variable frequency [1] |
+| [Android Health Connect](https://developer.android.com/health-connect)   | Sync On App Launch [2]      |
+| [Omron](https://www.omron-healthcare.com)                                | Manual Post             |
+| [Contour](https://www.diabetes.ascensia.com)                             | Manual Post             |
+| [Accu-Chek](https://www.accu-chek.com)                                   | Manual Post             |
+
+<Warning>
+[1] Notes on Sync on OS notification:
+
+Apple HealthKit notifies new data immediately only when your iOS app is in the foreground with visible UI.
+
+Meanwhile, [properly configured](/wearables/guides/apple_health_kit) HealthKit apps in background with no visible UI are
+notified on an OS-throttled, opportunistic schedule that can dynamically change based on factors like CPU usage, battery usage,
+connectivity, Low Power Mode, and delivery history.
+
+The Vital SDK — or any third-party HealthKit apps — has no control over this, other than _suggesting_
+a background delivery frequency to the OS as the lower bound. The actual delivery frequency
+remains at full discretion of the OS, and can range from hourly, to once a day, or
+when certain opportunity arises (e.g., when Sleep Mode ends, or when the phone starts charging).
+
+Therefore, it is not recommended to base your UX around immediate availability of HealthKit data. The only exception
+is if your UX do involve the user actively using your iOS app. For example, iOS 17+ supports third-party apps initiating
+an Apple Watch workout session that would be live synced with your iPhone app.
+</Warning>
+
+<Warning>
+[2] Notes on Sync On App Launch:
+
+Because Android Health Connect disallowes any data access when the app is in background, your app
+must be regularly opened by the end user for data to be synchronized. Hence, the Vital SDK can only
+provide Sync On App Launch as the default automatic behaviour.
+
+If automatic background monitoring is desired, your app would have to implement one of the [Android Foreground Service](https://developer.android.com/guide/components/foreground-services#background-start-restriction-exemptions)
+— e.g. high priority push from Firebase Cloud Messaging — during which your service manually initiate a Vital SDK sync.
+</Warning>
 
 ## Historical Days Retrieved
 


### PR DESCRIPTION
Reorganize the "Data Frequency" section in the Supported Provider page.

Clarify the behaviour of all SDK Based Providers, especially the Apple HealthKit and Android Health Connect restrictions/caveats.

