### PR TITLE
Replace `SnippetGroup` with `CodeGroup`

### DIFF
--- a/docs/home/quickstart.mdx
+++ b/docs/home/quickstart.mdx
@@ -93,7 +93,7 @@ Enter a new `client_user_id` and tap Create:
 
 This can also be achieved via the API as follows.
 
-<SnippetGroup>
+<CodeGroup>
 
 ```bash Creating a Vital user (bash)
 curl --request POST \
@@ -178,7 +178,7 @@ fmt.Printf("Received data %s\n", response)
 let user = try await VitalClient.shared.user.create(clientUserId)
 ```
 
-</SnippetGroup>
+</CodeGroup>
 
 ## 4. Connecting a source
 
@@ -304,7 +304,7 @@ summary data for a user. The request is simple and requires the Vital
 
 **Getting user sleep data**
 
-<SnippetGroup>
+<CodeGroup>
 
 ```python Python
 from vital.client import Vital
@@ -387,7 +387,7 @@ fmt.Printf("Received data %s\n", response)
 let sleepData = try await VitalClient.shared.summary.sleep(userId, startDate, endDate)
 ```
 
-</SnippetGroup>
+</CodeGroup>
 
 ## 6. SDK's and Libraries
 

--- a/docs/lab/overview/quickstart.mdx
+++ b/docs/lab/overview/quickstart.mdx
@@ -17,7 +17,7 @@ In the context of our API, a user refers to the patient who will be undergoing t
 
 You can find more details in our [API quickstart guide](/home/quickstart#3-creating-your-first-user).
 
-<SnippetGroup>
+<CodeGroup>
 
 ```bash Creating a Vital user (bash)
 curl --request POST \
@@ -98,13 +98,13 @@ if err != nil {
 fmt.Printf("Received data %s\n", response)
 ```
 
-</SnippetGroup>
+</CodeGroup>
 
 ### (2) Listing Available Tests
 
 To retrieve the set of lab tests you have access to, use the `/v3/lab_tests` API endpoint. In Sandbox, you will already have access to a default set of tests. Once you're ready to head to production, we can [setup a call](/lab/overview/introduction#production-launch) and get you ready for launch!
 
-<SnippetGroup>
+<CodeGroup>
 
 ```bash Listing available tests (bash)
 curl --request GET \
@@ -170,7 +170,7 @@ if err != nil {
 fmt.Printf("Received data %s\n", response)
 ```
 
-</SnippetGroup>
+</CodeGroup>
 
 This will return a list of all the available tests to you. They include a description, turnaround time and price:
 
@@ -213,7 +213,7 @@ You can then use the test `id` when creating an order.
 
 Ordering a test for your user is as simple as making an API call:
 
-<SnippetGroup>
+<CodeGroup>
 
 ```bash Ordering a test (bash)
 curl --request POST \
@@ -413,7 +413,7 @@ if err != nil {
 fmt.Printf("Received data %s\n", response)
 ```
 
-</SnippetGroup>
+</CodeGroup>
 
 ```json Response
 {

--- a/docs/lab/workflow/cancelling-an-order.mdx
+++ b/docs/lab/workflow/cancelling-an-order.mdx
@@ -21,7 +21,7 @@ When it comes to cancelling an order, to avoid the financial costs associated wi
 
 ### Cancel appointment endpoint
 
-<SnippetGroup>
+<CodeGroup>
 
 ```bash cURL
 curl --request PATCH \
@@ -104,7 +104,7 @@ if err != nil {
 fmt.Printf("Received data %s\n", response)
 ```
 
-</SnippetGroup>
+</CodeGroup>
 
 You will receive a response specifying awhether the order was successfully cancelled or not.
 
@@ -137,7 +137,7 @@ You will receive a response specifying awhether the order was successfully cance
 
 ### Cancel endpoint
 
-<SnippetGroup>
+<CodeGroup>
 
 ```bash cURL
 curl --request DELETE \
@@ -203,7 +203,7 @@ if err != nil {
 fmt.Printf("Received data %s\n", response)
 ```
 
-</SnippetGroup>
+</CodeGroup>
 
 You will receive a response specifying whether the order was successfully cancelled or not.
 

--- a/docs/lab/workflow/ordering.mdx
+++ b/docs/lab/workflow/ordering.mdx
@@ -33,7 +33,7 @@ There are multiple combinations allowed with this field, so let's explore all of
 
 When ordering from **one** previously created _Lab Test_, the `order_set` field should be populated as follows:
 
-<SnippetGroup>
+<CodeGroup>
 
 ```python Python
 from vital.client import Vital
@@ -51,13 +51,13 @@ client.lab_tests.create_order(
         ...
 )
 ```
-</SnippetGroup>
+</CodeGroup>
 
 ### Ordering from multiple _Lab Tests_
 
 You may want to combine two or more existing Lab Tests without creating a new one. This is possible by doing:
 
-<SnippetGroup>
+<CodeGroup>
 
 ```python Python
 from vital.client import Vital
@@ -75,7 +75,7 @@ client.lab_tests.create_order(
         ...
 )
 ```
-</SnippetGroup>
+</CodeGroup>
 
 ### Ordering without a _Lab Test_ 
 
@@ -87,7 +87,7 @@ This is a team level configuration that must be requested from Vital. Not all ma
 
 It is possible to order `a-la-carte` using Vital `marker_ids` or the lab's `provider_id`.
 
-<SnippetGroup>
+<CodeGroup>
 
 ```python Python
 from vital.client import Vital
@@ -109,13 +109,13 @@ client.lab_tests.create_order(
         ...
 )
 ```
-</SnippetGroup>
+</CodeGroup>
 
 ### Order _Lab Tests_ with extra _Markers_
 
 You may also add extra **markers** to an order. For example, you want to order the `Labcorp Lipid Panel and Vitamin D` but for this particular patient, you also want to order a `CBC Panel`.
 
-<SnippetGroup>
+<CodeGroup>
 
 ```python Python
 from vital.client import Vital
@@ -138,7 +138,7 @@ client.lab_tests.create_order(
         ...
 )
 ```
-</SnippetGroup>
+</CodeGroup>
 
 <Note>
 When supplying the `add_on` field, it is always required to provide the `collection_method` field.
@@ -151,7 +151,7 @@ Further explored in the documentation, Vital also has the concept of _Collection
 When ordering, you must select one of these, either at lab test creation, or at ordering time.
 
 
-<SnippetGroup>
+<CodeGroup>
 
 ```python Python
 from vital.client import Vital
@@ -170,13 +170,13 @@ client.lab_tests.create_order(
         ...
 )
 ```
-</SnippetGroup>
+</CodeGroup>
 
 ## À La Carte Markers
 
 As mentioned above, not all `markers` are `a la carte` orderable. You can find which one's are orderable via the [GET /v3/lab_tests/markers](/api-reference/lab-testing/biomarkers).
 
-<SnippetGroup>
+<CodeGroup>
 
 ```python Python
 from vital.client import Vital
@@ -195,7 +195,7 @@ markers = client.lab_tests.get_markers(
 if not all([m.a_la_carte_enabled for m in markers.markers]):
     raise Exception("Markers not a_la_carte_enabled")
 ```
-</SnippetGroup>
+</CodeGroup>
 
 
 

--- a/docs/wearables/connecting-providers/auth_types.mdx
+++ b/docs/wearables/connecting-providers/auth_types.mdx
@@ -35,7 +35,7 @@ Current OAuth providers are:
 
 To connect an oauth provider:
 
-<SnippetGroup>
+<CodeGroup>
 
 ```javascript Node
 import { VitalClient, VitalEnvironment } from '@tryvital/vital-node';
@@ -143,7 +143,7 @@ if err != nil {
 fmt.Printf("Received data %s\n", oauth)
 ```
 
-</SnippetGroup>
+</CodeGroup>
 
 For `OAuth` Providers we return an `oauth_url` that can be used to redirect users to. In a web view, on redirection, you should check the user has connected to the provider successfully. In the case of mobile, the user should receive a message to return to the app.
 
@@ -180,7 +180,7 @@ Current email and password providers are:
 
 To connect a email and password provider:
 
-<SnippetGroup>
+<CodeGroup>
 
 ```javascript Node
 import { VitalClient, VitalEnvironment } from '@tryvital/vital-node';
@@ -259,4 +259,4 @@ if err != nil {
 fmt.Printf("Received data %s\n", response)
 ```
 
-</SnippetGroup>
+</CodeGroup>

--- a/docs/wearables/connecting-providers/custom_widget.mdx
+++ b/docs/wearables/connecting-providers/custom_widget.mdx
@@ -16,7 +16,7 @@ An overview of the process is as follows:
 
 The first step to creating a custom widget is to make a call to the [providers endpoint](/docs/api-reference/providers). This will return a list of all available providers. You can then use this list to build your UI.
 
-<SnippetGroup>
+<CodeGroup>
 
 ```javascript Node
 import { VitalClient, VitalEnvironment } from "@tryvital/vital-node";
@@ -106,7 +106,7 @@ if err != nil {
 fmt.Printf("Received data %s\n", response)
 ```
 
-</SnippetGroup>
+</CodeGroup>
 
 ## 2. Build your UI in your app
 
@@ -125,7 +125,7 @@ Once you have a list of all available providers, you can build your UI. You can 
 
 Once a user has selected a provider, you can generate a link token. This link token is used to generate an oauth link, or authorize an email, or email and password. You can read more about the link token [here](/docs/api-reference/link#link-token-exchange).
 
-<SnippetGroup>
+<CodeGroup>
 
 ```javascript Node
 import { VitalClient, VitalEnvironment } from "@tryvital/vital-node";
@@ -204,7 +204,7 @@ response, err := client.Link.Token(context.TODO(), request)
 fmt.Printf("Received data %s\n", response)
 ```
 
-</SnippetGroup>
+</CodeGroup>
 
 ## 4. Link the user to the provider
 
@@ -212,7 +212,7 @@ Once you have a link token, you can use it to generate an oauth link, or authori
 
 ### Connect an oauth provider
 
-<SnippetGroup>
+<CodeGroup>
 
 ```javascript Node
 import { VitalClient, VitalEnvironment } from '@tryvital/vital-node';
@@ -320,11 +320,11 @@ if err != nil {
 fmt.Printf("Received data %s\n", oauth)
 ```
 
-</SnippetGroup>
+</CodeGroup>
 
 ### Connact an Email/Password provider
 
-<SnippetGroup>
+<CodeGroup>
 
 ```javascript Node
 import { VitalClient, VitalEnvironment } from '@tryvital/vital-node';
@@ -403,7 +403,7 @@ if err != nil {
 fmt.Printf("Received data %s\n", response)
 ```
 
-</SnippetGroup>
+</CodeGroup>
 
 ### Bringing this all together
 

--- a/docs/wearables/connecting-providers/launching_link.mdx
+++ b/docs/wearables/connecting-providers/launching_link.mdx
@@ -18,7 +18,7 @@ To do so, you just pass in the provider name as one of the parameter's to the li
 
 <br />
 
-<SnippetGroup>
+<CodeGroup>
 
 ```javascript Node
 import { VitalClient, VitalEnvironment } from '@tryvital/vital-node';
@@ -104,7 +104,7 @@ curl --request POST \
      --header 'x-vital-api-key: <API-KEY>'
 ```
 
-</SnippetGroup>
+</CodeGroup>
 <br />
 </Step>
 

--- a/docs/wearables/providers/test_data.mdx
+++ b/docs/wearables/providers/test_data.mdx
@@ -41,7 +41,7 @@ After creating the user, the `Users` page of your dashboard will look like this:
 
 Now you can create a demo connection for the Vital user you just created, in this case `150db84c-537c-4cad-a6e9-24dc589d7fa2`. You can directly hit the [API endpoint](/api-reference/link/link-demo-provider) or using one of our client libraries, as shown below:
 
-<SnippetGroup>
+<CodeGroup>
 
 ```bash Creating a demo connection
 curl --request POST \
@@ -125,7 +125,7 @@ if err != nil {
 fmt.Printf("Received data %s\n", response)
 ```
 
-</SnippetGroup>
+</CodeGroup>
 
 After the demo connection is created, a Fitbit logo will appear beside your user.
 


### PR DESCRIPTION
Hey! Ronan from Mintlify here

A while ago we renamed `SnippetGroup` to `CodeGroup`. We've been meaning to get rid of `SnippetGroup` for a while, but didn't want to break any docs. I did a quick search, and it appears you're our only customer still using it! Figured I would go ahead and make the PR myself to make it easy for you