### PR TITLE
[LAB-260] add deprecation for /v3/lab_tests

### DIFF
--- a/docs/api-reference/lab-testing/tests-paginated.mdx
+++ b/docs/api-reference/lab-testing/tests-paginated.mdx
@@ -1,9 +1,7 @@
 ---
 title: "Get Available Tests"
-openapi: "GET /v3/lab_tests"
+openapi: "GET /v3/lab_test"
 ---
-
-> **Deprecated:** This endpoint is deprecated. Please use the paginated version `/v3/lab_test` instead.
 
 <RequestExample>
 
@@ -16,7 +14,7 @@ client = Vital(
   environment=VitalEnvironment.SANDBOX
 )
 
-data = client.lab_tests.get();
+data = client.lab_tests.get_paginated();
 ```
 
 ```javascript Node
@@ -27,7 +25,7 @@ const client = new VitalClient({
     environment: VitalEnvironment.Sandbox,
 });
 
-const data = await client.labTests.get();
+const data = await client.labTests.getPaginated();
 ```
 
 
@@ -40,7 +38,7 @@ Vital vital = Vital.builder()
         .environment(Environment.SANDBOX)
         .build();
 
-var data = vital.labTests().get();
+var data = vital.labTests().getPaginated();
 ```
 
 ```go Go
@@ -49,15 +47,14 @@ import (
 
   vital "github.com/tryVital/vital-go"
   vitalclient "github.com/tryVital/vital-go/client"
-  "github.com/tryVital/vital-go/option"
 )
 
 client := vitalclient.NewClient(
-  option.WithApiKey("<YOUR_API_KEY>"),
-  option.WithBaseURL(vital.Environments.Sandbox),
+  vitalclient.WithApiKey("<YOUR_API_KEY>"),
+  vitalclient.WithBaseURL(vital.Environments.Sandbox),
 )
 
-response, err := client.LabTests.Get(context.TODO())
+response, err := client.LabTests.GetPaginated(context.TODO())
 if err != nil {
     return err
 }
@@ -70,32 +67,35 @@ fmt.Printf("Received data %s\n", response)
 <ResponseExample>
 
 ```json Response
-[
-  {
-    "lab_test": {
-      "name": "Lipids Panel",
-      "description": "Cholesterol test",
-      "sample_type": "dried blood spot",
-      "method": "testkit",
-      "price": 10,
-      "is_active": true,
-      "lab": {
-        "slug": "USSL",
-        "name": "US Specialty Lab",
-        "first_line_address": "123 Main St",
-        "city": "New York",
-        "zipcode": "10001"
-      },
-      "markers": [
-        {
-          "name": "Thyroid Stimulating Hormone",
-          "slug": "tsh",
-          "description": ""
-        }
-      ]
+{
+  "data": [
+    {
+      "lab_test": {
+        "name": "Lipids Panel",
+        "description": "Cholesterol test",
+        "sample_type": "dried blood spot",
+        "method": "testkit",
+        "price": 10,
+        "is_active": true,
+        "lab": {
+          "slug": "USSL",
+          "name": "US Specialty Lab",
+          "first_line_address": "123 Main St",
+          "city": "New York",
+          "zipcode": "10001"
+        },
+        "markers": [
+          {
+            "name": "Thyroid Stimulating Hormone",
+            "slug": "tsh",
+            "description": ""
+          }
+        ]
+      }
     }
-  }
-]
+  ],
+  "next_cursor": null
+}
 ```
 
 </ResponseExample>

--- a/docs/changelog/lab-testing/deprecations.mdx
+++ b/docs/changelog/lab-testing/deprecations.mdx
@@ -42,3 +42,7 @@ Parse the `result` field in accordance to the `result_type` field. [More informa
 ### `requisition_form_url` in the `order` object
 
 This field is a signed GCP bucket URL, which is only active for 7 days. It will be removed in favor of the [download PDF](/api-reference/lab-testing/requisition-pdf) endpoint.
+
+### `GET /v3/lab_tests` in favor of `GET /v3/lab_test`
+
+The endpoint `GET /v3/lab_tests` is deprecated in favor of `GET /v3/lab_test`. The new endpoint will return a paginated list of lab tests and supports two new parameters: `lab_test_limit` and `next_cursor`.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -440,6 +440,7 @@
                     "group": "Tests",
                     "pages": [
                       "api-reference/lab-testing/tests",
+                      "api-reference/lab-testing/tests-paginated",
                       "api-reference/lab-testing/biomarkers",
                       "api-reference/lab-testing/labs",
                       "api-reference/lab-testing/post-test",
@@ -1423,6 +1424,7 @@
                     "group": "Tests",
                     "pages": [
                       "api-reference/lab-testing/tests",
+                      "api-reference/lab-testing/tests-paginated",
                       "api-reference/lab-testing/biomarkers",
                       "api-reference/lab-testing/labs",
                       "api-reference/lab-testing/post-test",


### PR DESCRIPTION
Updates lab testing docs to reflect that `/v3/lab_tests` is deprecated in favour of `/v3/lab_test`.