### PR TITLE
Fix Garmin provider rate limit typo

### DIFF
--- a/docs/wearables/connecting-providers/bring-your-own-oauth/overview.mdx
+++ b/docs/wearables/connecting-providers/bring-your-own-oauth/overview.mdx
@@ -51,7 +51,7 @@ This section documents the _starting_ rate limit of a brand new OAuth applicatio
 | Provider                                             | Starting Rate Limit                                                                 |
 | ---------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | [Fitbit](https://www.fitbit.com/global/uk/home)      | 150 requests per hour per user                                                      |
-| [Garmin](https://www.garmin.com)                     | 10,000 days of data oer minute                                                      |
+| [Garmin](https://www.garmin.com)                     | 10,000 days of data per minute                                                      |
 | [Google Fit](https://www.google.com/fit/)            | 600 requests per minute                                                             |
 | [Oura](https://ouraring.com)                         | 5,000 requests per 5 minutes                                                        |
 | [Strava](https://www.strava.com)                     | 100 requests per 15 minutes<br />1,000 requests per day                             | 


### PR DESCRIPTION
## References

- https://docs.tryvital.io/wearables/connecting-providers/bring-your-own-oauth/overview#provider-rate-limits

## Scope

On the `Wearables` section, for the connecting providers, there is a typo for the `Garmin` one within the [rate limits chapter](https://docs.tryvital.io/wearables/connecting-providers/bring-your-own-oauth/overview#provider-rate-limits): "oer" that should be "per".

Take a look at the illustration below:

<img width="1104" alt="Screenshot 2025-03-11 at 19 25 33" src="https://github.com/user-attachments/assets/646db6aa-5721-4fd0-b985-f7859cd04794" />
