### PR TITLE
📝 [LAB-780] Add gender restriction information to ordering workflow page

### DIFF
--- a/docs/lab/workflow/ordering.mdx
+++ b/docs/lab/workflow/ordering.mdx
@@ -210,3 +210,4 @@ With the existance of various allowed combinations with the `order_set` field, t
 3. `cannot set both marker_ids and provider_ids in add_on`: Similarly, only one of the former fields can be provided.
 4. `cannot order lab_tests from multiple labs`: You can only order multiple lab tests from the same lab.
 5. `cannot order with lab tests with multiple collection methods`: You must supply a `collection_method` if ordering multiple lab tests with multiple collection methods.
+6. `Lab <lab name> does not allow gender <gender value>`: The associated lab restricts which patient genders it accepts. This restriction applies to the entire lab, not to individual lab tests.


### PR DESCRIPTION
### WHAT

- Related PR stack: https://github.com/tryVital/vital-mono/pull/9452
- This PR clarifies documents the "disallowed genders" restriction as part of the ordering workflow

NOTE: Do not merge until the related PR stack has been merged and deployed.

![CleanShot 2025-06-19 at 11 35 23@2x](https://github.com/user-attachments/assets/a896e878-f564-4968-bfd2-1b4e8e80bcb9)
