### PR TITLE
[CE-145] Remove iHealth support

### DIFF
--- a/docs/wearables/connecting-providers/auth_types.mdx
+++ b/docs/wearables/connecting-providers/auth_types.mdx
@@ -24,7 +24,6 @@ Current OAuth providers are:
 | `Oura`       | Smart Sleep tracking ring                                     |
 | `Strava`     | Running & Cycling Social Network                              |
 | `Wahoo`      | Cycling Equipment                                             |
-| `iHealth`    | Blood pressure, Fitness scales, Glucometers & Fitness watches |
 | `Withings`   | Fitness scales, watches and health monitors                   |
 | `Google Fit` | Activity Trackers (all devices)                               |
 | `Polar`      | Finnish sports tech pioneer                                   |

--- a/docs/wearables/providers/introduction.mdx
+++ b/docs/wearables/providers/introduction.mdx
@@ -51,7 +51,6 @@ Some BYOO providers do not have a developer program with open sign-up.
 | Provider (Slug)                                                          | Description                                                   | Availability                                                                         | Remarks |
 | ------------------------------------------------------------------------ | ------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------- |
 | [Dexcom](https://www.dexcom.com)                 <br />`dexcom_v3`       | Dexcom CGM Glucose monitors                                   | ⚠️ [BYOO only](/wearables/connecting-providers/bring_your_own_oauth)                  | Password Auth<br />[↗️ Guide](/wearables/guides/dexcom_v3) |
-| [iHealth](https://ihealthlabs.com)               <br />`ihealth`         | Blood pressure, Fitness scales, Glucometers & Fitness watches | ⚠️  [BYOO only](/wearables/connecting-providers/bring_your_own_oauth)                 | OAuth |
 | [WHOOP](https://www.whoop.com)                   <br />`whoop_v2`        | Your Personal Digital Fitness and Health Coach                | ⚠️  [BYOO](/wearables/connecting-providers/bring_your_own_oauth) only                 | OAuth<br />[↗️ Guide](/wearables/guides/whoop) |
 | [MyFitnessPal API](https://www.myfitnesspalapi.com) <br />`my_fitness_pal_v2` | Nutrition data                                           | ⚠️  [BYOO](/wearables/connecting-providers/bring_your_own_oauth) only                 | OAuth |
 | [MapMyFitness](https://developer.mapmyfitness.com)         <br />`map_my_fitness`  | Technology for all atheletes                        | ⚠️  [BYOO](/wearables/connecting-providers/bring_your_own_oauth) only                 | OAuth |
@@ -133,7 +132,6 @@ Cloud Based Providers can be divided in two main categories:
 | [Strava](https://www.strava.com)                                | Push        |
 | [Wahoo](https://wahoofitness.com)                               | Push        |
 | [Withings](https://www.withings.com)                            | Push        |
-| [iHealth](https://ihealthlabs.com)                              | Push        |
 | [Freestyle](https://www.freestylelibre.co.uk/libre/)(API + SDK) | Polling     |
 | [Google Fit](https://www.google.com/fit/)                       | Polling     |
 | [Oura](https://ouraring.com)                                    | Polling     |

--- a/docs/wearables/providers/timestamps-and-time-zones.mdx
+++ b/docs/wearables/providers/timestamps-and-time-zones.mdx
@@ -67,7 +67,6 @@ Each provider has their own affinity of time zone information:
 | [WHOOP](https://www.whoop.com)                           `whoop_v2`             | ✅                              | ✅                               | _N/A_                            | |
 | [Zwift](https://zwift.com)                               `zwift`                | _N/A_                           | User Fallback, or Absent         | _N/A_                            | |
 | [Withings](https://www.withings.com)                     `withings`             | ✅                              | ✅                               | ✅                               | |
-| [iHealth](https://ihealthlabs.com)                       `ihealth`              | _N/A_                           | ✅                               | Absent                           | |
 | [8Sleep](https://www.eightsleep.com)                     `eight_sleep`          | _N/A_                           | ✅                               | ✅                               | |
 | [Hammerhead](https://www.hammerhead.io)                  `hammerhead`           | _N/A_                           | Inferred, or Absent              | Inferred, or Absent              | |
 | [Dexcom](https://www.dexcom.com)                         `dexcom_v3`            | _N/A_                           | _N/A_                            | ✅                               | |


### PR DESCRIPTION
IHealth has deprecated their OAuth support, so we can no longer support this integration.