### PR TITLE
add note about within_radius

### DIFF
--- a/docs/api-reference/lab-testing/area-info.mdx
+++ b/docs/api-reference/lab-testing/area-info.mdx
@@ -104,7 +104,7 @@ fmt.Printf("Received data %s\n", response)
   "central_labs": {
     "labcorp": {
       "patient_service_centers": {
-        "within_radius": 5,
+        "within_radius": 5, # number of PSC's within radius of provided zip code
         "radius": "25",
         "capabilities": ["stat"]
       }


### PR DESCRIPTION
## Issue

When implementing the API there was some confusion to what this field meant.

Ref support ticket #22415

## Solution

Adding a comment in the response body example. This same comment in the example response is already implemented [here](https://github.com/tryVital/docs/blob/main/docs/lab/overview/locations.mdx?plain=1#L18) in main.

I would have liked to put some description in the actual docs, but it looks like that is perhaps auto-generated in the swager json and would require and update to the API itself.