### PR TITLE
Remove beta labels from redraws docs

### DIFF
--- a/docs/lab/walk-in/order-lifecycle.mdx
+++ b/docs/lab/walk-in/order-lifecycle.mdx
@@ -3,8 +3,6 @@ title: "Order and Appointment Lifecycle"
 description: "Learn the order and appointment statuses, state transitions, and scheduling flows for Walk-In Phlebotomy lab tests."
 ---
 
-import FeatureBeta from '/snippets/feature-beta.mdx';
-
 The **Walk-In Test** orders are composed of two different lifecycles, the **Order** lifecycle and
 the **Appointment** lifecycle, detailed in the following sections.
 
@@ -23,7 +21,7 @@ For each modality, there can be multiple **low-level statuses**, for **Walk-In P
 - `appointment_scheduled`: An appointment was scheduled or rescheduled for the order.
 - `appointment_cancelled`: The appointment was cancelled, by either the patient, Vital or you.
 - `partial_results`: The laboratory has started making partial results available.
-- `redraw_available`: The result has been marked as final but is missing biomarker results due to lab error. (Currently in beta testing.)
+- `redraw_available`: The result has been marked as final but is missing biomarker results due to lab error.
 - `completed`: The laboratory processed the blood sample and final results are available.
 - `sample_error`: The collected sample was unprocessable by the lab.
 - `cancelled`: The order was cancelled by either the patient, Vital or you.

--- a/docs/lab/workflow/lab-test-lifecycle.mdx
+++ b/docs/lab/workflow/lab-test-lifecycle.mdx
@@ -93,7 +93,7 @@ Below is a full list of all the available statuses by test modality. The names s
 - `collecting_sample.walk_in_test.appointment_pending`
 - `collecting_sample.walk_in_test.appointment_scheduled`
 - `collecting_sample.walk_in_test.appointment_cancelled`
-- `collecting_sample.walk_in_test.redraw_available` (currently in beta testing)
+- `collecting_sample.walk_in_test.redraw_available`
 - `sample_with_lab.walk_in_test.partial_results`
 - `completed.walk_in_test.completed`
 - `failed.walk_in_test.sample_error`

--- a/docs/lab/workflow/redraws.mdx
+++ b/docs/lab/workflow/redraws.mdx
@@ -3,10 +3,6 @@ title: "Redraws"
 description: "Handle redraw scenarios where patients return for a new blood draw due to missing results."
 ---
 
-import FeatureBeta from '/snippets/feature-beta.mdx';
-
-<FeatureBeta />
-
 <Warning>
 Please note that this feature is only available for walk-in tests with Labcorp, Quest, and BioReference.
 </Warning>


### PR DESCRIPTION
Redraws are GA — removes the closed-beta callout and the "(currently in beta testing)" annotations across the three pages that referenced it.

Pages changed:
- `docs/lab/workflow/redraws.mdx` — dropped the `<FeatureBeta />` callout
- `docs/lab/workflow/lab-test-lifecycle.mdx` — removed annotation from `redraw_available` in walk-in statuses list
- `docs/lab/walk-in/order-lifecycle.mdx` — removed annotation from `redraw_available` status description

Note: "On-site collection statuses (currently in beta testing)" in `lab-test-lifecycle.mdx` is a separate feature and was left untouched.