### PR TITLE
Capitalize PSC in lab-testing docs titles/descriptions

### DIFF
--- a/docs/api-reference/lab-testing/order-psc-info.mdx
+++ b/docs/api-reference/lab-testing/order-psc-info.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Get order PSC info"
-description: "Retrieve order psc info via the Junction API. Requires authentication with your team API key."
+description: "Retrieve order PSC info via the Junction API. Requires authentication with your team API key."
 openapi: "GET /v3/order/{order_id}/psc/info"
 ---
 

--- a/docs/api-reference/lab-testing/psc-info.mdx
+++ b/docs/api-reference/lab-testing/psc-info.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Get PSC info"
-description: "Retrieve order psc info via the Junction API. Requires authentication with your team API key."
+description: "Retrieve order PSC info via the Junction API. Requires authentication with your team API key."
 openapi: "GET /v3/order/psc/info"
 ---
 

--- a/docs/api-reference/lab-testing/psc-info.mdx
+++ b/docs/api-reference/lab-testing/psc-info.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Get psc info"
+title: "Get PSC info"
 description: "Retrieve order psc info via the Junction API. Requires authentication with your team API key."
 openapi: "GET /v3/order/psc/info"
 ---

--- a/docs/api-reference/lab-testing/psc-scheduling/appointment-psc-availability.mdx
+++ b/docs/api-reference/lab-testing/psc-scheduling/appointment-psc-availability.mdx
@@ -1,7 +1,7 @@
 ---
 openapi: "POST /v3/order/psc/appointment/availability"
 title: "PSC Appointment Availability"
-description: "Create or submit order psc appointment availability via the Junction API. Requires authentication with your team API key."
+description: "Create or submit order PSC appointment availability via the Junction API. Requires authentication with your team API key."
 ---
 
 import FeatureBeta from '/snippets/feature-beta.mdx';

--- a/docs/api-reference/lab-testing/psc-scheduling/appointment-psc-booking.mdx
+++ b/docs/api-reference/lab-testing/psc-scheduling/appointment-psc-booking.mdx
@@ -1,7 +1,7 @@
 ---
 openapi: "POST /v3/order/{order_id}/psc/appointment/book"
 title: "Book PSC Appointment"
-description: "Create or submit order psc appointment book via the Junction API. Requires authentication with your team API key."
+description: "Create or submit order PSC appointment book via the Junction API. Requires authentication with your team API key."
 ---
 
 import FeatureBeta from '/snippets/feature-beta.mdx';

--- a/docs/api-reference/lab-testing/psc-scheduling/appointment-psc-cancellation-reasons.mdx
+++ b/docs/api-reference/lab-testing/psc-scheduling/appointment-psc-cancellation-reasons.mdx
@@ -1,7 +1,7 @@
 ---
 openapi: "GET /v3/order/psc/appointment/cancellation-reasons"
 title: "PSC Appointment Cancellation Reasons"
-description: "Retrieve order psc appointment cancellation-reasons via the Junction API. Requires authentication with your team API key."
+description: "Retrieve order PSC appointment cancellation-reasons via the Junction API. Requires authentication with your team API key."
 ---
 
 <RequestExample>

--- a/docs/api-reference/lab-testing/psc-scheduling/appointment-psc-cancelling.mdx
+++ b/docs/api-reference/lab-testing/psc-scheduling/appointment-psc-cancelling.mdx
@@ -1,7 +1,7 @@
 ---
 openapi: "PATCH /v3/order/{order_id}/psc/appointment/cancel"
 title: "Cancel PSC Appointment"
-description: "Partially update order psc appointment cancel via the Junction API. Requires authentication with your team API key."
+description: "Partially update order PSC appointment cancel via the Junction API. Requires authentication with your team API key."
 ---
 
 <RequestExample>

--- a/docs/api-reference/lab-testing/psc-scheduling/appointment-psc-rescheduling.mdx
+++ b/docs/api-reference/lab-testing/psc-scheduling/appointment-psc-rescheduling.mdx
@@ -1,7 +1,7 @@
 ---
 openapi: "PATCH /v3/order/{order_id}/psc/appointment/reschedule"
 title: "Reschedule PSC Appointment"
-description: "Partially update order psc appointment reschedule via the Junction API. Requires authentication with your team API key."
+description: "Partially update order PSC appointment reschedule via the Junction API. Requires authentication with your team API key."
 ---
 
 <RequestExample>

--- a/docs/api-reference/lab-testing/psc-scheduling/get-psc-appointment.mdx
+++ b/docs/api-reference/lab-testing/psc-scheduling/get-psc-appointment.mdx
@@ -1,7 +1,7 @@
 ---
 openapi: "GET /v3/order/{order_id}/psc/appointment"
 title: "Get PSC Appointment"
-description: "Retrieve order psc appointment via the Junction API. Requires authentication with your team API key."
+description: "Retrieve order PSC appointment via the Junction API. Requires authentication with your team API key."
 ---
 
 <RequestExample>


### PR DESCRIPTION
PSC is an acronym and wasn't being capitalized consistently across the lab-testing API reference pages — some titles had it right, others (and every description) had it lowercase. Fixed the psc-info title and the lowercase "psc" in the description of all 8 PSC-related pages.