### PR TITLE
Add note that new PSCs are coming soon

### DIFF
--- a/docs/lab/overview/locations.mdx
+++ b/docs/lab/overview/locations.mdx
@@ -7,6 +7,10 @@ description: "Find and verify nearby Patient Service Centers (PSCs) for walk-in 
 
 Verifying if a particular zip code is serviceable is an important step, as not all labs have patient service centers within a state or within a reasonable distance.
 
+<Note>
+  New Patient Service Centers are coming soon, expanding coverage and availability.
+</Note>
+
 The recommended high-level flow for verifying PSC availability at Junction is:
 
 1. Fetch PSC location data via the `GET` [Area Info](/api-reference/lab-testing/area-info) endpoint, the response payload should look like this:


### PR DESCRIPTION
## Summary
- Adds a note to the Patient Service Centers and Appointments doc letting users know new PSCs are coming soon, expanding coverage and availability.

## Test plan
- [ ] Preview rendered docs page to confirm the note displays correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)