### PR TITLE
Document Junction Sense time and data semantics

### DIFF
--- a/docs/continuous-query-overview.mdx
+++ b/docs/continuous-query-overview.mdx
@@ -57,7 +57,7 @@ Continuous Query runs your Junction Sense Queries automatically across all users
 
   **Example: First Glucose Reading of Each Day**
 
-  - Capture fasting glucose values (first measurement per day)
+  - Capture the first observed glucose value in each local-day bucket
   - Group by data source and provider for device comparison
   - Track morning glucose patterns over time
   - [View example →](/sense/examples#first-glucose-measurement-of-the-day-grouped-by-source-type-and-provider)
@@ -144,7 +144,7 @@ Calculate meaningful insights using built-in [aggregation functions](/sense/quer
 - **Sum** - Total steps, cumulative calories
 - **Min/Max** - Lowest/highest values in a period
 - **Standard Deviation** - Variability in metrics
-- **Newest/Oldest** - Most recent or first value (useful for fasting glucose, chronotype)
+- **Newest/Oldest** - Value from the latest or earliest table index (useful for the first observed glucose value or the latest chronotype)
 
 ### Multi-Dimensional Grouping
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1194,6 +1194,7 @@
                 "group": "Junction Sense",
                 "pages": [
                   "sense/overview",
+                  "sense/time-and-data-semantics",
                   "continuous-query-overview",
                   "sense/using-continuous-query",
                   "sense/managing-queries",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1194,7 +1194,6 @@
                 "group": "Junction Sense",
                 "pages": [
                   "sense/overview",
-                  "sense/time-and-data-semantics",
                   "continuous-query-overview",
                   "sense/using-continuous-query",
                   "sense/managing-queries",
@@ -1206,6 +1205,7 @@
               {
                 "group": "Query DSL",
                 "pages": [
+                  "sense/query-dsl/time-and-data-semantics",
                   "sense/query-dsl/column-expressions",
                   "sense/query-dsl/select-clause",
                   "sense/query-dsl/group-by-clause",

--- a/docs/sense/data-prioritization.mdx
+++ b/docs/sense/data-prioritization.mdx
@@ -13,6 +13,8 @@ Within each group outlined by your [Group By clause](/sense/query-dsl/group-by-c
 * Keep only data from the sub-group that has the highest Source Type priority, or the highest Provider priority when multiple sub-groups exist
   for the same Source Type.
 
+The selected provider and source-type pair contributes the complete aggregate output for that group. Sense does not combine individual fields from different source pairs.
+
 <Note>
 Data prioritization works only in a [Group By](/sense/query-dsl/group-by-clause) context.
 </Note>
@@ -20,6 +22,16 @@ Data prioritization works only in a [Group By](/sense/query-dsl/group-by-clause)
 <Note>
 If both the _Provider_ and _Source Type_ Source Columns are present in the [Group By clause](/sense/query-dsl/group-by-clause),
 the implicit [Data Prioritization](/sense/data-prioritization) behavior would be disabled.
+</Note>
+
+## Scope of prioritization
+
+Prioritization uses the provider and source type. It does not rank individual devices, source device IDs, or source app IDs.
+
+To inspect source-specific results, group by both `source_provider` and `source_type`. This produces a separate result for each available pair and disables implicit selection of one winning pair. You can also group by a resource's optional `source_device_id` table column when it is available, but provider coverage for that field varies.
+
+<Note>
+[Readiness Scores](/sense/query-dsl/readiness-scores) select the highest-priority eligible Sleep source internally for each date. The public `derived_readiness` table does not expose source fields, so it cannot be grouped by provider or source type.
 </Note>
 
 <Accordion title="Example" defaultOpen>

--- a/docs/sense/examples.mdx
+++ b/docs/sense/examples.mdx
@@ -390,7 +390,7 @@ va.select(
 
 ## Menstrual Cycle Summary
 
-Period end, cycle end, mean basal body temperature, and number of meaningful flow days — one row per cycle.
+Period end, cycle end, mean basal body temperature, and number of meaningful flow days — one row per period-start date.
 
 <CodeGroup>
 ```python Python DSL
@@ -398,8 +398,8 @@ import vitalx.aggregation as va
 
 va.select(
     va.group_key("*"),
-    va.MenstrualCycle.col("period_end").newest(),
-    va.MenstrualCycle.col("cycle_end").newest(),
+    va.MenstrualCycle.col("period_end").max(),
+    va.MenstrualCycle.col("cycle_end").max(),
     va.MenstrualCycle.col("basal_body_temperature")
         .unnest_and_select(lambda col: col.field("value").mean())
         .mean(),
@@ -416,8 +416,8 @@ va.select(
 {
   "select": [
     { "group_key": "*" },
-    { "func": "newest", "arg": { "menstrual_cycle": "period_end" } },
-    { "func": "newest", "arg": { "menstrual_cycle": "cycle_end" } },
+    { "func": "max", "arg": { "menstrual_cycle": "period_end" } },
+    { "func": "max", "arg": { "menstrual_cycle": "cycle_end" } },
     {
       "func": "mean",
       "arg": {

--- a/docs/sense/overview.mdx
+++ b/docs/sense/overview.mdx
@@ -20,7 +20,7 @@ experimentation.
 </Card>
 
 <Card title="Aggregate in floating time" icon="timeline-arrow" horizontal>
-  Work with time zone agnostic outputs that are indexed in the user's perception of time (i.e., _floating time_).
+  Work with outputs indexed in the user's local perception of time. Review the [time and data semantics](/sense/time-and-data-semantics) before interpreting daily buckets as elapsed time or data coverage.
 </Card>
 
 ## Query API and Continuous Query
@@ -43,6 +43,9 @@ You can use Junction Sense through two mediums:
 <Steps>
   <Step title="Experiment with Query API">
     Start with Query API if you need quick insights, one-time analysis or query experimentation using an individual user's data.
+  </Step>
+  <Step title="Confirm time and source semantics">
+    Check the table index, floating-time behavior, provider attribution, and prioritization before treating an output as a production data contract.
   </Step>
   <Step title="Productize with Continuous Query">
     Switch to Continuous Query once you have queries which you wish to turn into a continuously updated, named dataset and to receive change events for.

--- a/docs/sense/overview.mdx
+++ b/docs/sense/overview.mdx
@@ -20,7 +20,7 @@ experimentation.
 </Card>
 
 <Card title="Aggregate in floating time" icon="timeline-arrow" horizontal>
-  Work with outputs indexed in the user's local perception of time. Review the [time and data semantics](/sense/time-and-data-semantics) before interpreting daily buckets as elapsed time or data coverage.
+  Work with outputs indexed in the user's local perception of time. Review the [time and data semantics](/sense/query-dsl/time-and-data-semantics) before interpreting daily buckets as elapsed time or data coverage.
 </Card>
 
 ## Query API and Continuous Query

--- a/docs/sense/query-dsl/column-expressions.mdx
+++ b/docs/sense/query-dsl/column-expressions.mdx
@@ -279,11 +279,15 @@ the implicit [Data Prioritization](/sense/data-prioritization) behavior would be
 
 | Column                                | Python DSL                           | JSON DSL                           | Available in |
 | ------------------------------------- | ------------------------------------ | -----------------------------------|----------------------------- |
-| Provider                              | `Source.col("source_provider")`      | `{ "source": "source_provider" }`  | All Tables |
-| Source Type                           | `Source.col("source_type")`          | `{ "source": "source_type" }`      | All Tables |
-| Source App ID                         | `Source.col("source_app_id")`        | `{ "source": "source_app_id" }`    | All summary tables |
+| Provider                              | `Source.col("source_provider")`      | `{ "source": "source_provider" }`  | Summary and timeseries tables except Readiness Scores |
+| Source Type                           | `Source.col("source_type")`          | `{ "source": "source_type" }`      | Summary and timeseries tables except Readiness Scores |
+| Source App ID                         | `Source.col("source_app_id")`        | `{ "source": "source_app_id" }`    | Summary tables except Readiness Scores |
 | Workout ID                            | `Source.col("source_workout_id")`    | `{ "source": "source_workout_id" }` | Workout Stream timeseries only |
 | Sport                                 | `Source.col("source_sport")`         | `{ "source": "source_sport" }`     | Workout Stream timeseries only |
+
+<Note>
+`source_device_id` is an optional table column on supported summary resources, not a Source Column expression. For example, use `Activity.col("source_device_id")` or `{ "activity": "source_device_id" }`. Do not use `{ "source": "source_device_id" }`. Coverage and stability vary by provider.
+</Note>
 
 ## Index Column expression
 
@@ -297,7 +301,9 @@ index using the special Index Column expression:
 | Sleep summary<br/>`sleep`            | Session end datetime   | `Sleep.index()`     | `{ "index": "sleep" }` |
 | Readiness scores<br/>`derived_readiness` | Calendar date       | `DerivedReadiness.index()` | `{ "index": "derived_readiness" }` |
 | Workout summary<br/>`workout`        | Session start datetime | `Workout.index()`   | `{ "index": "workout" }` |
+| Meal summary<br/>`meal`              | Calendar date          | `Meal.index()`      | `{ "index": "meal" }` |
 | Menstrual cycle<br/>`menstrual_cycle`| Period start date      | `MenstrualCycle.index()` | `{ "index": "menstrual_cycle" }` |
+| Timeseries<br/>`timeseries`           | Sample timestamp       | `Timeseries.index()` | `{ "index": "timeseries" }` |
 | Profile<br/>`profile`                | Updated At (UTC) datetime | `Profile.index()`| `{ "index": "profile" }` |
 
 

--- a/docs/sense/query-dsl/group-by-clause.mdx
+++ b/docs/sense/query-dsl/group-by-clause.mdx
@@ -32,7 +32,7 @@ tracks your declaration order.
 Group the input rows based on the specified column expression truncated to the specified granularity.
 This is similar to the `DATE_TRUNC` function in SQL.
 
-Date truncation uses the table's [floating-time index](/sense/time-and-data-semantics). A daily bucket represents a local calendar day, not a guaranteed 24-hour elapsed interval.
+Date truncation uses the table's [floating-time index](/sense/query-dsl/time-and-data-semantics). A daily bucket represents a local calendar day, not a guaranteed 24-hour elapsed interval.
 
 <AccordionGroup>
 <Accordion title="Input argument" icon="arrow-right-to-bracket" iconType="duotone" defaultOpen>

--- a/docs/sense/query-dsl/group-by-clause.mdx
+++ b/docs/sense/query-dsl/group-by-clause.mdx
@@ -32,6 +32,8 @@ tracks your declaration order.
 Group the input rows based on the specified column expression truncated to the specified granularity.
 This is similar to the `DATE_TRUNC` function in SQL.
 
+Date truncation uses the table's [floating-time index](/sense/time-and-data-semantics). A daily bucket represents a local calendar day, not a guaranteed 24-hour elapsed interval.
+
 <AccordionGroup>
 <Accordion title="Input argument" icon="arrow-right-to-bracket" iconType="duotone" defaultOpen>
 

--- a/docs/sense/query-dsl/list-column-aggregation.mdx
+++ b/docs/sense/query-dsl/list-column-aggregation.mdx
@@ -138,14 +138,14 @@ The predicate grammar is the same as the top-level [WHERE clause](/sense/query-d
 
 A scalar-output subquery in a grouped query must be wrapped in an outer aggregate.
 
-Period end, cycle end, and number of meaningful flow days, one row per cycle:
+Period end, cycle end, and number of meaningful flow days, one row per period-start date:
 
 <CodeGroup>
 ```python Python DSL
 va.select(
     va.group_key("*"),
-    va.MenstrualCycle.col("period_end").newest(),
-    va.MenstrualCycle.col("cycle_end").newest(),
+    va.MenstrualCycle.col("period_end").max(),
+    va.MenstrualCycle.col("cycle_end").max(),
     va.MenstrualCycle.col("menstrual_flow")
         .unnest_and_select(lambda col: col.count())
         .where("flow != 'none'")
@@ -159,8 +159,8 @@ va.select(
 {
     "select": [
         { "group_key": "*" },
-        { "func": "newest", "arg": { "menstrual_cycle": "period_end" } },
-        { "func": "newest", "arg": { "menstrual_cycle": "cycle_end" } },
+        { "func": "max", "arg": { "menstrual_cycle": "period_end" } },
+        { "func": "max", "arg": { "menstrual_cycle": "cycle_end" } },
         {
             "func": "mean",
             "arg": {
@@ -179,6 +179,14 @@ va.select(
 }
 ```
 </CodeGroup>
+
+More than one normalized Menstrual Cycle record can share a period-start date, including records attributed to different source apps within the selected provider and source type. The outer aggregate combines those record-level scalars:
+
+- `sum(inner_count)` counts matching elements across the records.
+- `min(inner_min)` and `max(inner_max)` select the extrema across the records.
+- `mean(inner_mean)` is an unweighted mean of the record-level means, not a pooled mean of all list elements.
+
+For a pooled mean, calculate an inner `sum` and `count`, aggregate each with outer `sum`, and divide the resulting totals in your application. Avoid `oldest` or `newest` when records can share the same period-start index because ties are not defined.
 
 ## Supported aggregates
 

--- a/docs/sense/query-dsl/readiness-scores.mdx
+++ b/docs/sense/query-dsl/readiness-scores.mdx
@@ -18,6 +18,8 @@ The `derived_readiness` table returns one row per user and calendar day with:
 
 Junction Sense computes these metrics for you, so you can query readiness directly without building custom scoring pipelines.
 
+For each date, Junction selects the highest-priority eligible Sleep provider and source type before materializing the Readiness Scores row. The public table does not expose `source_provider`, `source_type`, or other source-attribution columns. Query the Sleep table separately if you need to audit source changes or compare providers.
+
 ## What you can do
 
 - Pull one scored row per day for charting or downstream analytics.

--- a/docs/sense/query-dsl/select-clause.mdx
+++ b/docs/sense/query-dsl/select-clause.mdx
@@ -63,6 +63,15 @@ Aggregate a [Table Column expression](/sense/query-dsl/column-expressions) with 
 The specified aggregate function is applied to each and every group created by the `group_by` clause.
 The result set is N aggregated values where N is the number of groups.
 
+| Function | Input semantics |
+| --- | --- |
+| `count` | Counts non-null values in the selected column. |
+| `mean` | Calculates the unweighted arithmetic mean of the input rows. A mean of precomputed session or daily metrics is not weighted by duration or sample count. |
+| `oldest` / `newest` | Selects the value from the row with the earliest or latest [table index](/sense/time-and-data-semantics#start-with-the-table-index). If multiple rows have the same index, the tie result is not defined. |
+| `sum` | Adds the stored input values. Sense does not normalize for elapsed bucket duration or reconcile overlapping timeseries intervals. |
+
+See [Time and data semantics](/sense/time-and-data-semantics) for floating-time, correction, overlap, and completeness behavior.
+
 
 <AccordionGroup>
 <Accordion title="Statistical functions" icon="chart-column" iconType="duotone" defaultOpen>

--- a/docs/sense/query-dsl/select-clause.mdx
+++ b/docs/sense/query-dsl/select-clause.mdx
@@ -67,10 +67,10 @@ The result set is N aggregated values where N is the number of groups.
 | --- | --- |
 | `count` | Counts non-null values in the selected column. |
 | `mean` | Calculates the unweighted arithmetic mean of the input rows. A mean of precomputed session or daily metrics is not weighted by duration or sample count. |
-| `oldest` / `newest` | Selects the value from the row with the earliest or latest [table index](/sense/time-and-data-semantics#start-with-the-table-index). If multiple rows have the same index, the tie result is not defined. |
+| `oldest` / `newest` | Selects the value from the row with the earliest or latest [table index](/sense/query-dsl/time-and-data-semantics#start-with-the-table-index). If multiple rows have the same index, the tie result is not defined. |
 | `sum` | Adds the stored input values. Sense does not normalize for elapsed bucket duration or reconcile overlapping timeseries intervals. |
 
-See [Time and data semantics](/sense/time-and-data-semantics) for floating-time, correction, overlap, and completeness behavior.
+See [Time and data semantics](/sense/query-dsl/time-and-data-semantics) for floating-time, correction, overlap, and completeness behavior.
 
 
 <AccordionGroup>

--- a/docs/sense/query-dsl/time-and-data-semantics.mdx
+++ b/docs/sense/query-dsl/time-and-data-semantics.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Time and data semantics"
 description: "Understand how Junction Sense indexes records, creates local-time buckets, handles source corrections, and interprets summary and timeseries data."
+icon: clock
 ---
 
 Junction Sense aggregates normalized wearable data. Before choosing an aggregate function, identify what one input row represents and which timestamp or date Sense uses as the table index.

--- a/docs/sense/time-and-data-semantics.mdx
+++ b/docs/sense/time-and-data-semantics.mdx
@@ -1,0 +1,82 @@
+---
+title: "Time and data semantics"
+description: "Understand how Junction Sense indexes records, creates local-time buckets, handles source corrections, and interprets summary and timeseries data."
+---
+
+Junction Sense aggregates normalized wearable data. Before choosing an aggregate function, identify what one input row represents and which timestamp or date Sense uses as the table index.
+
+## Start with the table index
+
+`date_trunc`, `oldest`, and `newest` all use the selected table's index.
+
+| Table | Index used by Sense |
+| --- | --- |
+| Activity | Calendar date |
+| Body | Measurement datetime |
+| Sleep | Session end datetime |
+| Workout | Session start datetime |
+| Meal | Calendar date |
+| Menstrual Cycle | Period start date |
+| Readiness Scores | Calendar date |
+| Timeseries | Sample timestamp |
+| Profile | `updated_at` in UTC |
+
+For example, a sleep session that starts before midnight and ends after midnight belongs to the local-day bucket containing its session end.
+
+## Floating time
+
+Except for Profile, Sense evaluates dates and times in **floating time**: the local date and clock time associated with the record, without converting every record to one shared UTC timeline.
+
+This preserves the user's experience of time. A 7:00 AM sample remains 7:00 AM when grouped by hour, even when the user changes time zones.
+
+For timeseries data, Sense derives floating time from each sample's stored time zone offset. If the offset is missing or unusable, Sense uses an offset of zero. Historical offset quality depends on the provider.
+
+### Consequences for daily buckets
+
+- A local-day bucket does not represent a fixed 24-hour elapsed interval. Travel can cause one bucket to span more or less elapsed time.
+- Daylight saving transitions are not normalized. A spring-forward or fall-back day remains one local calendar day.
+- A result does not distinguish a short local day from incomplete wear time, delayed sync, or missing provider data.
+- The minimum and maximum floating timestamps describe local clock positions. Do not subtract them to calculate elapsed UTC duration across an offset change.
+- Sense does not normalize sums or means by the number of elapsed hours in a bucket.
+
+If elapsed duration or data completeness matters, retrieve the underlying data and apply the completeness rules required by your application.
+
+## Resource-specific behavior
+
+### Activity
+
+Activity is a normalized daily summary. In normal ingestion paths, Sense receives one current summary per user, provider, and calendar date. A provider correction updates that logical daily summary instead of adding another device contribution.
+
+`source_device_id` is optional attribution metadata. It is not a source-prioritization key, and grouping by it cannot recover separate device records that a provider already combined into one daily summary.
+
+`time_zone_offset` is the last observed offset reported for the day. It does not describe wear duration, coverage, or time spent in each time zone. Activity intensity fields are provider-defined daily values and are not guaranteed to partition a 24-hour day.
+
+### Sleep
+
+Sleep is indexed by the floating session end datetime. Sense aggregates the normalized `duration_second` stored on each Sleep record; it does not recalculate session duration during query evaluation. How the provider integration obtains that duration can vary.
+
+The optional `time_zone` field describes the normalized Sleep record. Do not use it to infer time zone transitions within a session.
+
+### Timeseries
+
+Sense uses the samples and intervals stored from the provider. It does not resample them to a uniform cadence or reconcile all overlapping intervals.
+
+Within the same stored series, a correction at the exact same timestamp replaces the earlier value. Values at different timestamps remain separate, even when their intervals overlap. Aggregates such as `sum` operate on the values that remain, so overlapping intervals can both contribute.
+
+Sampling frequency, interval length, and update behavior vary by provider and resource. Validate representative provider data before depending on a fixed cadence or non-overlapping intervals.
+
+## Summary and timeseries values are independent
+
+A provider's summary metric and its related timeseries are separate normalized products. They may use different provider endpoints, synchronization windows, or provider-defined calculations. Sense does not require a summary total to equal an aggregate calculated from timeseries samples.
+
+Use summary tables when you want the provider's normalized daily or session-level metric. Use timeseries when your application needs sample-level analysis, custom coverage rules, or elapsed-time calculations.
+
+## Query design checklist
+
+Before deploying a query:
+
+1. Confirm the table index and whether it matches the date assignment your application expects.
+2. Decide whether you need the prioritized result or separate provider and source-type groups.
+3. Check whether missing data can be distinguished from a valid low or short result.
+4. Verify sample cadence, interval overlap, and source attribution with representative providers.
+5. Use the [Query API](/sense/using-query-api) to test travel, daylight saving, duplicate-index, and sparse-data cases before creating a Continuous Query.

--- a/docs/sense/using-continuous-query.mdx
+++ b/docs/sense/using-continuous-query.mdx
@@ -41,6 +41,10 @@ While Continuous Query uses the same [Query DSL](/sense/query-dsl/) as the Query
 - The query must [select all group key columns](/sense/query-dsl/select-clause#select-the-group-key-columns).
 
 <Note>
+An ungrouped Readiness Scores query is a supported exception when it directly selects the `date` column and readiness values. See [Readiness Scores](/sense/query-dsl/readiness-scores).
+</Note>
+
+<Note>
   Please reach out if your use case is limited by these restrictions.
 </Note>
 
@@ -51,6 +55,15 @@ data event to your [Webhook or ETL Pipeline destinations](/webhooks/introduction
 
 This data event includes only the delta (new rows or changed rows with respect to the [group keys](/sense/query-dsl/select-clause#select-the-group-key-columns)).
 To re-fetch the whole result set, use the [Get Result Table](/api-reference/sense/continuous-query/get-result-table) endpoint.
+
+Treat this event as a notification that the result table changed, not as an ordered event log:
+
+- The event does not include a query evaluation timestamp, sequence number, result version, or task ID.
+- Webhook delivery can be retried or arrive out of order. Deduplicate webhook retries with the `svix-id` header; do not use `svix-timestamp` as query evaluation time or an ordering key.
+- Fetch the latest result table before making a stateful workflow decision. This prevents an older or retried delivery from regressing application state.
+- The `data` object uses columnar JSON. Arrays at the same position form one row. For example, index `0` in every array belongs to the same changed row.
+
+If you only need to trigger a refresh, enqueue the `query_id` and `user_id`, return a successful response promptly, and fetch the current table asynchronously.
 
 ```json
 {


### PR DESCRIPTION
## Summary

- add a central Junction Sense guide for table indexes, floating time, corrections, source attribution, and summary versus timeseries behavior
- place the relevant contracts in the aggregate, grouping, prioritization, list-column, Readiness, and Continuous Query guides
- document result-table events as change notifications with columnar deltas rather than ordered state logs
- add a production query-design checklist for new and repeat developers

## Corrections included

- describe the first daily glucose value as first observed rather than fasting
- use deterministic max aggregation for Menstrual Cycle end dates when records share an index
- clarify that Readiness Scores select a Sleep source internally and do not expose source columns
- add missing Meal and Timeseries index entries and the correct source_device_id expression shape