### PR TITLE
Docs Updates

### DIFF
--- a/docs/api-reference/lab-testing/cancel-order.mdx
+++ b/docs/api-reference/lab-testing/cancel-order.mdx
@@ -90,20 +90,20 @@ fmt.Printf("Received data %s\n", response)
         "user_id": {
           "title": "User Id",
           "type": "string",
-          "description": "User id returned by vital create user request. This id should be stored in your database against the user and used for all interactions with the vital api.",
+          "description": "User id returned by Junction create user request. This id should be stored in your database against the user and used for all interactions with the Junction api.",
           "format": "uuid"
         },
         "user_key": {
           "title": "User Key",
           "type": "string",
-          "description": "User key returned by vital create user key request. This key should be stored in your database against the user and used for all interactions with the vital api.",
+          "description": "User key returned by Junction create user key request. This key should be stored in your database against the user and used for all interactions with the Junction api.",
           "format": "uuid",
           "deprecated": true
         },
         "id": {
           "title": "Id",
           "type": "string",
-          "description": "The Vital Order ID",
+          "description": "The Junction Order ID",
           "format": "uuid"
         },
         "team_id": {
@@ -369,7 +369,7 @@ fmt.Printf("Received data %s\n", response)
               "description": "Schema for a LabTest in the database."
             }
           ],
-          "description": "The Vital Test associated with the order"
+          "description": "The Junction Test associated with the order"
         },
         "details": {
           "title": "Details",
@@ -392,7 +392,7 @@ fmt.Printf("Received data %s\n", response)
                     "id": {
                       "title": "Id",
                       "type": "string",
-                      "description": "The Vital walk-in test Order ID",
+                      "description": "The Junction walk-in test Order ID",
                       "format": "uuid"
                     },
                     "created_at": {
@@ -433,7 +433,7 @@ fmt.Printf("Received data %s\n", response)
                     "id": {
                       "title": "Id",
                       "type": "string",
-                      "description": "The Vital TestKit Order ID",
+                      "description": "The Junction TestKit Order ID",
                       "format": "uuid"
                     },
                     "shipment": {
@@ -456,7 +456,7 @@ fmt.Printf("Received data %s\n", response)
                             "id": {
                               "title": "Id",
                               "type": "string",
-                              "description": "The Vital Shipment ID",
+                              "description": "The Junction Shipment ID",
                               "format": "uuid"
                             },
                             "outbound_tracking_number": {
@@ -492,7 +492,7 @@ fmt.Printf("Received data %s\n", response)
                             "notes": {
                               "title": "Notes",
                               "type": "string",
-                              "description": "Notes associated to the Vital shipment"
+                              "description": "Notes associated to the Junction shipment"
                             }
                           },
                           "description": "Schema for a Shipment in the client facing API.\n\nTo be used as part of a ClientFacingTestkitOrder.",

--- a/docs/lab/workflow/cancelling-an-order.mdx
+++ b/docs/lab/workflow/cancelling-an-order.mdx
@@ -50,7 +50,7 @@ Orders **cannot** be cancelled once they reach these states:
     - `collecting_sample.walk_in_test.redraw_available` - Order marked as final but has missing results
     - `failed.walk_in_test.sample_error` - Sample error occurred
 
-    <Info>Cancelling a walk-in test order does **not** automatically cancel PSC appointments to prevent a poor patient experience, as it could lead to a patient arriving and their appointment being cancelled. Use the [PSC appointment cancellation endpoint](/api-reference/lab-testing/psc-scheduling/appointment-psc-cancelling) if you need to cancel the appointment separately. Orders can be reinstated by our support team if a patient shows up for an appointment related to a cancelled order.</Info>
+    <Info>Cancelling a walk-in test order does **not** automatically cancel PSC appointments. Use the [PSC appointment cancellation endpoint](/api-reference/lab-testing/psc-scheduling/appointment-psc-cancelling) to cancel the appointment separately.</Info>
   </Tab>
 
   <Tab title="Mobile Phlebotomy">


### PR DESCRIPTION
- Remove outdated hardcoded references to "Vital". There are others but they all stem from the SDK at this point.
- Remove a promise we can't keep about reinstating cancelled orders. Now some customers are on requisition cancellation this is misleading and all the others should go (ideally) through unmatched results